### PR TITLE
Fix typo in setup page

### DIFF
--- a/app/partials/setup.html
+++ b/app/partials/setup.html
@@ -3,7 +3,7 @@
     <form>
       <div class="row">
         <div class="col-md-12">
-          <h3>Generation (2-6)</h3>
+          <h3>Generation (2-7)</h3>
         </div>
       </div>
       <div class="row">


### PR DESCRIPTION
I found a little typo error in the setup page -> Generation (2-6) and not Generation (2-7).
This PR fix this 😄